### PR TITLE
Bugfix delete tags from bookmarks

### DIFF
--- a/frontend/src/app/bookmarks/bookmarks-list/bookmarks-list.component.ts
+++ b/frontend/src/app/bookmarks/bookmarks-list/bookmarks-list.component.ts
@@ -165,7 +165,7 @@ export class BookmarksListComponent implements OnInit, OnDestroy {
     const buttonValue = button.value;
     for (const tagsKey in this.editedBookmark.tags) {
       if (this.editedBookmark.tags[tagsKey].name === buttonValue){
-        this.editedBookmark.tags.splice(Number(tagsKey), 1 + Number(tagsKey));
+        this.editedBookmark.tags.splice(Number(tagsKey), 1);
       }
     }
   }

--- a/frontend/src/app/bookmarks/bookmarks-list/bookmarks-list.component.ts
+++ b/frontend/src/app/bookmarks/bookmarks-list/bookmarks-list.component.ts
@@ -37,13 +37,13 @@ export class BookmarksListComponent implements OnInit, OnDestroy {
       this.bookmarkService.getBookmarks().subscribe({
         next: bookmarks => {
           this.route.queryParams.subscribe(params => {
+            this.getTags();
+            this.getFolders();
             if (params.category){
-              this.getFolders();
               this.bookmarks = [];
               this.bookmarks = this.prepareBookmark(bookmarks, params.category);
               return;
             }if (params.tag){
-              this.getTags();
               this.bookmarks = [];
               this.bookmarks = this.prepareBookmarkByTag(bookmarks, params.tag);
               return;

--- a/frontend/src/app/bookmarks/bookmarks-list/bookmarks-list.component.ts
+++ b/frontend/src/app/bookmarks/bookmarks-list/bookmarks-list.component.ts
@@ -91,8 +91,9 @@ export class BookmarksListComponent implements OnInit, OnDestroy {
     this.bookmarkService.deleteBookmark(this.editedBookmark)
       .subscribe(data => {
         console.log('Successful');
+        this.updateBookmarksList('delete');
       });
-    window.location.reload();
+    this.contentModal.hide();
   }
 
   editBookmark(): void {
@@ -105,13 +106,14 @@ export class BookmarksListComponent implements OnInit, OnDestroy {
       this.bookmarkService.editBookmark(this.editedBookmark)
         .subscribe(data => {
           console.log('Successful');
+          this.updateBookmarksList('edit');
         });
     } else {
       this.bookmarkService.addBookmark(this.editedBookmark)
         .subscribe(data => {
           console.log('Successful');
+          this.bookmarks.push(this.editedBookmark);
         });
-      window.location.reload();
     }
     this.contentModal.hide();
   }
@@ -197,5 +199,18 @@ export class BookmarksListComponent implements OnInit, OnDestroy {
         },
         error: err => this.errorMessage = err
       });
+  }
+
+  private updateBookmarksList(action: string):void {
+    for(const bookmarkKey in this.bookmarks) {
+      if (this.bookmarks[bookmarkKey].bookmarkId === this.editedBookmark.bookmarkId){
+        if (action === 'delete') {
+          this.bookmarks.splice(Number(bookmarkKey), 1);
+        }
+        if (action === 'edit') {
+          this.bookmarks[bookmarkKey] = this.editedBookmark;
+        }
+      }
+    }
   }
 }

--- a/frontend/src/app/bookmarks/sidebar/sidebar.component.html
+++ b/frontend/src/app/bookmarks/sidebar/sidebar.component.html
@@ -1,7 +1,7 @@
 <!--<p>sidebar works!</p>-->
 <div class="header-and-nav bg-primary d-flex flex-row flex-md-column p-3">
   <header class="d-flex order-2 order-md-1">
-    <a href="/bookmarks" class="text-light">
+    <a [routerLink]="['/bookmarks']" class="text-light">
       <span class="material-icons logo-icon align-text-bottom">bookmark_border</span>
       <span class="logo-text">bookmark-manager</span>
     </a>
@@ -13,7 +13,7 @@
     <div class="nav-menu bg-primary d-flex flex-column">
       <ul class="m-0 p-0 list-unstyled">
         <li class="menu-link">
-          <a href="/bookmarks" class="text-light">
+          <a [routerLink]="['/bookmarks']" class="text-light">
             <span class="material-icons align-middle py-1">collections_bookmark</span> All
           </a>
         </li>

--- a/frontend/src/app/bookmarks/sidebar/tag-list/tag-list.component.ts
+++ b/frontend/src/app/bookmarks/sidebar/tag-list/tag-list.component.ts
@@ -66,6 +66,7 @@ export class TagListComponent implements OnInit, OnDestroy {
       this.tagService.editTag(this.editedTag)
         .subscribe(data => {
           console.log('Successful');
+          this.updateTagList();
         });
     }
     this.content.hide();
@@ -84,9 +85,16 @@ export class TagListComponent implements OnInit, OnDestroy {
 
   private removeTagFromList(): void{
     for(const tagsKey in this.tags) {
-      console.log(this.tags[tagsKey]);
       if (this.tags[tagsKey].id === this.editedTag.id){
         this.tags.splice(Number(tagsKey), 1);
+      }
+    }
+  }
+
+  private updateTagList() {
+    for(const tagsKey in this.tags) {
+      if (this.tags[tagsKey].id === this.editedTag.id){
+        this.tags[tagsKey] = this.editedTag;
       }
     }
   }


### PR DESCRIPTION
Done:
On delete tag from bookmark edit, delete only one tag per click
On edit tag, update dynamically view
Add, update and delete bookmarks without reload page